### PR TITLE
Remove asyncio dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "requests","aiohttp","asyncio"
+    "requests","aiohttp",
 ]
 keywords = ["suez","toutsurmoneau","water consumption"]
 


### PR DESCRIPTION
The `asyncio` dependency is only relevant for Python 3.3 which isn't supported anyway.
https://pypi.org/project/asyncio/