### PR TITLE
Use SPDX license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,10 @@ authors = [
 ]
 description = "Get your water consumption data from your Suez account (www.toutsurmoneau.fr or www.eau-olivet.fr)"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "Apache-2.0"
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
 dependencies = [


### PR DESCRIPTION
`hatchling` recommends to use the official SPDX license expression, i.e. `Apache-2.0`.
https://hatch.pypa.io/latest/config/metadata/#spdx-expression