### PR TITLE
Fix non handled 204 No Content reponse

### DIFF
--- a/src/pysuez/suez_client.py
+++ b/src/pysuez/suez_client.py
@@ -450,6 +450,8 @@ class SuezClient:
     ) -> bool:
         _LOGGER.debug(f"{url} responded with {response.status}")
         if response.status >= 200 and response.status < 300:
+            if response.status == 204:
+                return False
             return True
         if response.status >= 300 and response.status < 400:
             redirection_target = response.headers.get("Location")


### PR DESCRIPTION
Hi,

I was testing your latest HA feature (https://github.com/home-assistant/core/pull/131166) for storing water consumption in stats, but encountered a bug on my end.
When fetching a date older than 2 years (Suez history doesn't exceed 24 months), I got a 204 No Content response from the telemetry API, with empty body. This led to the line "response.json()" throwing an exception an the HA integration failing to sync the data.

So this PR is as simple as that : handle the 204 response to end the data fetching.
Tested on a 2024.4.4 Homeassistant with the suez_water integration code from your PR quoted above. I hope this one will be merged soon with this little fix on Pysuez!

Regards,